### PR TITLE
docs: refactor CHANGELOG.md to follow Django package conventions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,30 +5,38 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.1.0] - 2025-01-15
+## 0.1.0 
+-------------------
 
-### Added
-- Time-based cache invalidation with timezone support
-- Cron-based cache invalidation with flexible scheduling
-- Database analytics and performance tracking
-- Django Admin integration for cache entries and event history
-- Management commands for cache status, analytics, and clearing
-- Comprehensive cache key validation
-- Type hints throughout the codebase
-- Modular architecture with separated concerns
-- Robust error handling with graceful degradation
+**New features**
 
-### Features
-- `@easy_cache.time_based()` decorator for daily invalidation at specific times
-- `@easy_cache.cron_based()` decorator for flexible cron-based invalidation
-- Automatic cache key generation with collision avoidance
-- Database models for cache analytics (CacheEntry, CacheEventHistory)
-- Management commands: `status`, `analytics`, `clear`
-- Django Admin interface at `/admin/django_easy_cache/`
+* Time-based cache invalidation with timezone support
+* Cron-based cache invalidation with flexible scheduling
+* Database analytics and performance tracking
+* Django Admin integration for cache entries and event history
+* Management commands for cache status, analytics, and clearing
+* `@easy_cache.time_based()` decorator for daily invalidation at specific times
+* `@easy_cache.cron_based()` decorator for flexible cron-based invalidation
+* Automatic cache key generation with collision avoidance
+* Database models for cache analytics (CacheEntry, CacheEventHistory)
+* Management commands: `status`, `analytics`, `clear`
+* Django Admin interface at `/admin/django_easy_cache/`
 
-### Technical
-- Built on Django's cache framework for backend compatibility
-- Support for Redis, Memcached, Database, and Local Memory cache backends
-- Atomic database operations for analytics tracking
-- Thread-safe cache operations
-- Comprehensive test suite with pytest
+**Bug fixes**
+
+* Fix package name configuration for Sphinx documentation
+* Resolve CI database conflicts and modernize database configuration
+* Allow CI to run pre-commit on protected branches while enforcing local branch restrictions
+
+**Technical improvements**
+
+* Built on Django's cache framework for backend compatibility
+* Support for Redis, Memcached, Database, and Local Memory cache backends
+* Atomic database operations for analytics tracking
+* Thread-safe cache operations
+* Comprehensive cache key validation
+* Type hints throughout the codebase
+* Modular architecture with separated concerns
+* Robust error handling with graceful degradation
+* Comprehensive test suite with pytest
+* Replace pre-commit branch restrictions with GitHub rulesets

--- a/Dockerfile
+++ b/Dockerfile
@@ -70,7 +70,8 @@ RUN apt-get update && \
       # Translations dependencies:
       gettext \
       git \
-      locales && \
+      locales \
+      make && \
     sed -i -e "s/# en_GB.UTF-8.*/en_GB.UTF-8 UTF-8/" /etc/locale.gen && \
     sed -i -e "s/# de_DE.UTF-8.*/de_DE.UTF-8 UTF-8/" /etc/locale.gen && \
     locale-gen de_DE.UTF-8 &&\

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,4 +4,4 @@
    :maxdepth: 1
    :caption: Contents:
 
-   features/changelog.md
+.. mdinclude:: ../CHANGELOG.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ dev = [
     'pre-commit',
     'sphinx',
     'sphinx-rtd-theme',
+    'm2r2',
 ]
 redis = [
     "redis>=5.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.11"
 
 [[package]]
@@ -382,7 +382,7 @@ wheels = [
 
 [[package]]
 name = "django-easy-cache"
-version = "0.1.0a1"
+version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "cron-converter" },
@@ -398,6 +398,7 @@ dev = [
     { name = "django-stubs", extra = ["compatible-mypy"] },
     { name = "factory-boy" },
     { name = "ipython" },
+    { name = "m2r2" },
     { name = "pre-commit" },
     { name = "psycopg", extra = ["binary"] },
     { name = "pytest" },
@@ -438,6 +439,7 @@ requires-dist = [
     { name = "django-stubs", extras = ["compatible-mypy"], marker = "extra == 'dev'", specifier = "~=5.2" },
     { name = "factory-boy", marker = "extra == 'dev'" },
     { name = "ipython", marker = "extra == 'dev'" },
+    { name = "m2r2", marker = "extra == 'dev'" },
     { name = "pre-commit", marker = "extra == 'dev'" },
     { name = "psycopg", extras = ["binary"], marker = "extra == 'dev'", specifier = "~=3.2" },
     { name = "psycopg2-binary", marker = "extra == 'postgresql'", specifier = ">=2.9.0" },
@@ -766,6 +768,19 @@ wheels = [
 ]
 
 [[package]]
+name = "m2r2"
+version = "0.3.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "docutils" },
+    { name = "mistune" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/26/a9/ab03ff21972cfb2e6ea766b1dc015c2c081af70f8f956806e948c62044ba/m2r2-0.3.4.tar.gz", hash = "sha256:e278f5f337e9aa7b2080fcc3e94b051bda9615b02e36c6fb3f23ff019872f043", size = 17082, upload-time = "2025-05-01T16:55:53.244Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a9/50/5b1d70de548fb1e11e15ea9ebec0480365462d202f98b66ad7e154284327/m2r2-0.3.4-py3-none-any.whl", hash = "sha256:1a445514af8a229496bfb1380c52da8dd38313e48600359ee92b2c9d2e4df34a", size = 11199, upload-time = "2025-05-01T16:55:51.87Z" },
+]
+
+[[package]]
 name = "markdown-it-py"
 version = "4.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -844,6 +859,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "mistune"
+version = "0.8.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2d/a4/509f6e7783ddd35482feda27bc7f72e65b5e7dc910eca4ab2164daf9c577/mistune-0.8.4.tar.gz", hash = "sha256:59a3429db53c50b5c6bcc8a07f8848cb00d7dc8bdb431a4ab41920d201d4756e", size = 58322, upload-time = "2018-10-11T06:59:27.908Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/09/ec/4b43dae793655b7d8a25f76119624350b4d65eb663459eb9603d7f1f0345/mistune-0.8.4-py2.py3-none-any.whl", hash = "sha256:88a1051873018da288eee8538d476dffe1262495144b33ecb586c4ab266bb8d4", size = 16220, upload-time = "2018-10-11T06:59:26.044Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- Convert from Keep a Changelog format to Django package style
- Replace bracketed version with plain version format
- Reorganize content into standard Django sections (New features, Bug fixes, Technical improvements)
- Add recent bug fixes and improvements from git history
- Use consistent bullet point formatting with asterisks
- Remove redundant categorization and consolidate related items